### PR TITLE
changes for LSSTTD-1140 and LSSTTD-1158

### DIFF
--- a/python/ccsTools.py
+++ b/python/ccsTools.py
@@ -118,6 +118,12 @@ class CcsRaftSetup(CcsSetup):
             self.set_item('ccd_names["%s"]' % slot, 'SensorInfo("%s", "%s")'
                           % (str(sensor.sensor_id),
                              str(sensor.manufacturer_sn)))
+
+#        # aliveness bench reb serial numbers:
+#        for slot, reb_sn in zip(('REB0', 'REB1', 'REB2'),
+#                                [412220615, 412162821, 305879976]):
+#            raft.rebs[slot].manufacturer_sn = '%x' % reb_sn
+
         for slot, reb in raft.rebs.items():
             self.set_item('reb_eT_info["%s"]' % slot,
                           'RebInfo("%s", "%s", "%s")'

--- a/python/ccsTools.py
+++ b/python/ccsTools.py
@@ -106,9 +106,11 @@ class CcsRaftSetup(CcsSetup):
         super(CcsRaftSetup, self).__init__(configFile, sys_paths=sys_paths)
         self.commands.append('from collections import namedtuple')
         self.commands.append("SensorInfo = namedtuple('SensorInfo', 'sensor_id manufacturer_sn'.split())")
+        self.commands.append("RebInfo = namedtuple('RebInfo', 'reb_id manufacturer_sn firmware_version'.split())")
         self.commands.append("ccd_names = dict()")
-        self._get_ccd_names()
-    def _get_ccd_names(self):
+        self.commands.append("reb_eT_info = dict()")
+        self._get_ccd_and_reb_names()
+    def _get_ccd_and_reb_names(self):
         raft_id = siteUtils.getUnitId()
         raft = camera_components.Raft.create_from_etrav(raft_id)
         for slot in raft.slot_names:
@@ -116,6 +118,11 @@ class CcsRaftSetup(CcsSetup):
             self.set_item('ccd_names["%s"]' % slot, 'SensorInfo("%s", "%s")'
                           % (str(sensor.sensor_id),
                              str(sensor.manufacturer_sn)))
+        for slot, reb in raft.rebs.items():
+            self.set_item('reb_eT_info["%s"]' % slot,
+                          'RebInfo("%s", "%s", "%s")'
+                          % (reb.reb_id, reb.manufacturer_sn,
+                             reb.firmware_version))
         ccd_type = str(raft.sensor_type.split('-')[0])
         self['ccd_type'] = ccd_type
         if ccd_type == 'ITL':

--- a/python/ccs_python_proxies.py
+++ b/python/ccs_python_proxies.py
@@ -53,10 +53,18 @@ class Ts8Proxy(NullSubsystem):
         self.responses = dict()
         self.responses['getREBDeviceNames'] \
             = ProxyResponse(('R00.Reb0', 'R00.Reb1', 'R00.Reb2'))
+        self.responses['getREBDevices'] \
+            = ProxyResponse(('R00.Reb0', 'R00.Reb1', 'R00.Reb2'))
         self.responses['getREBHwVersions'] \
             = ProxyResponse([808599560, 808599560, 808599560])
+        #self.responses['getREBSerialNumbers'] \
+        #    = ProxyResponse([305877457, 305892521, 305879138])
+#        # aliveness bench REBs:
+#        self.responses['getREBSerialNumbers'] \
+#            = ProxyResponse([412220615, 412162821, 305879976])
+        # ETU1 REBs:
         self.responses['getREBSerialNumbers'] \
-            = ProxyResponse([305877457, 305892521, 305879138])
+            = ProxyResponse([412165857, 412223738, 412160431])
         self.responses['printGeometry 3'] = ProxyResponse('''--> R00
 ---> R00.Reb2
 ----> R00.Reb2.Sen20
@@ -71,6 +79,7 @@ class Ts8Proxy(NullSubsystem):
 ----> R00.Reb0.Sen01
 ----> R00.Reb0.Sen02
 ''')
+        self.responses['getREBIds'] = ProxyResponse((0, 1, 2))
     def synchCommand(self, *args):
         command = ' '.join([str(x) for x in args[1:]])
         try:

--- a/python/ccs_scripting_tools.py
+++ b/python/ccs_scripting_tools.py
@@ -13,9 +13,10 @@ class SubsystemDecorator(object):
     Decorator class to overlay logging of the commands sent to a CCS
     subsystem object.
     """
-    def __init__(self, ccs_subsystem, logger=None):
+    def __init__(self, ccs_subsystem, logger=None, name=None):
         self.ccs_subsystem = ccs_subsystem
         self.logger = logger
+        self.name = name
 
     def _log_command(self, args):
         if self.logger is not None:

--- a/python/ccs_scripting_tools.py
+++ b/python/ccs_scripting_tools.py
@@ -62,10 +62,11 @@ class CcsSubsystems(object):
             if value in self._proxy_subsystems:
                 proxy_subsystem = ccs_python_proxies.CCS.attachSubsystem(value)
                 self.__dict__[key] = SubsystemDecorator(proxy_subsystem,
-                                                        logger=logger)
+                                                        logger=logger,
+                                                        name=value)
                 continue
             self.__dict__[key] = SubsystemDecorator(CCS.attachSubsystem(value),
-                                                    logger=logger)
+                                                    logger=logger, name=value)
         self._get_version_info(subsystems)
 
     def _get_version_info(self, subsystems):

--- a/python/ts8_utils.py
+++ b/python/ts8_utils.py
@@ -1,6 +1,7 @@
 """
 Utilities to work with the ts8 subsystem.
 """
+from collections import namedtuple
 
 def write_REB_info(ts8sub, outfile='reb_info.txt'):
     """
@@ -21,6 +22,31 @@ def write_REB_info(ts8sub, outfile='reb_info.txt'):
     with open(outfile, 'w') as output:
         for reb_info in zip(reb_names, fw_vers, SNs):
             output.write('%s  %x  %x\n' % reb_info)
+
+def get_REB_info(ts8sub, rebid):
+    """
+    Retrieve the REB device name, firmware version, and manufacturer
+    serial number for the specified REB ID.
+
+    Parameters
+    ----------
+    ts8sub : CCS subsystem
+        The ts8 subsystem.
+    rebid : int
+        The REB ID.
+
+    Returns
+    -------
+    namedtuple : (REB device name, firmware version, serial number)
+    """
+    RebInfo = namedtuple('RebInfo', 'deviceName hwVersion serialNumber'.split())
+    rebids = list(ts8sub.synchCommand(10, 'getREBIds').getResult())
+    dev_names = list(ts8sub.synchCommand(10, 'getREBDevices').getResult())
+    hw_versions = list(ts8sub.synchCommand(10, 'getREBHwVersions').getResult())
+    serial_numbers \
+        = list(ts8sub.synchCommand(10, 'getREBSerialNumbers').getResult())
+    index = rebids.index(rebid)
+    return RebInfo(dev_names[index], hw_versions[index], serial_numbers[index])
 
 def set_ccd_info(ccs_sub, ccd_names, logger):
     """

--- a/python/ts8_utils.py
+++ b/python/ts8_utils.py
@@ -44,7 +44,8 @@ def get_REB_info(ts8sub, rebid):
     dev_names = list(ts8sub.synchCommand(10, 'getREBDevices').getResult())
     hw_versions = list(ts8sub.synchCommand(10, 'getREBHwVersions').getResult())
     serial_numbers \
-        = list(ts8sub.synchCommand(10, 'getREBSerialNumbers').getResult())
+        = ['%x' % x for x in
+           ts8sub.synchCommand(10, 'getREBSerialNumbers').getResult()]
     index = rebids.index(rebid)
     return RebInfo(dev_names[index], hw_versions[index], serial_numbers[index])
 


### PR DESCRIPTION
The JIRA issue to implement the xy-staging acquisitions ([LSSTTD-1140](https://jira.slac.stanford.edu/browse/LSSTTD-1140)) requires the change adding the CCS subsystem name to the `SubsystemDecorator` class.

The other change is adding the `ts8Utils.get_REB_info` function for the aliveness test power-on update in [LSSTTD-1158](https://jira.slac.stanford.edu/browse/LSSTTD-1158).