### PR TITLE
add Clearning and Clearcount responses on ts8-proxy

### DIFF
--- a/python/ccs_python_proxies.py
+++ b/python/ccs_python_proxies.py
@@ -80,6 +80,8 @@ class Ts8Proxy(NullSubsystem):
 ----> R00.Reb0.S02
 ''')
         self.responses['getREBIds'] = ProxyResponse((0, 1, 2))
+        self.responses['getSequencerParameter CleaningNumber'] = ProxyResponse([0, 0, 0])
+        self.responses['getSequencerParameter ClearCount'] = ProxyResponse([1, 1, 1])
     def synchCommand(self, *args):
         command = ' '.join([str(x) for x in args[1:]])
         try:


### PR DESCRIPTION
A current version of an EO_acquisition script needs some response to the following commands
```
getSequencerParameter CleaningNumber
getSequencerParameter ClearCount
```
I have implemented the responses so that the acquisition script goes through.

Ideally, passing definitions from a sequencer file loaded is appropriate but the responses are hardcoded.